### PR TITLE
fix: correcting error message shown to user

### DIFF
--- a/app/action/register.js
+++ b/app/action/register.js
@@ -28,7 +28,7 @@ export const register = async(values) => {
         if (err.name === 'ValidationError')
         {
             return {
-                error: "Password too short."
+                error: err.message
             };
         }
     }


### PR DESCRIPTION
Error was always displaying "password too short." now it displays which user field was not properly met.